### PR TITLE
Update gradle-wrapper.properties

### DIFF
--- a/Android Application/gradle/wrapper/gradle-wrapper.properties
+++ b/Android Application/gradle/wrapper/gradle-wrapper.properties
@@ -4,3 +4,5 @@ distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionSha256Sum=5c07b3bac2209fbc98fb1fdf6fd831f72429cdf8c503807404eae03d8c8099e5
+#distributionSha256Sum must be updated along with the version of gradle in distributionUrl


### PR DESCRIPTION
Hi,

This small PR adds the `distributionSha256Sum` property to `gradle-wrapper.properties`. It allows for verification of the downloaded Gradle distribution via SHA-256 hash sum comparison.

You can find some documentation about this security improvement [here](https://docs.gradle.org/current/userguide/gradle_wrapper.html#sec:verification), and the sums for each version of gradle [here](https://services.gradle.org/distributions/).

Note that you need to update this property every time you change your version of gradle.

(Should I remove the comment at the end of gradle-wrapper.properties? It's here to remind you of changing the value of this property...)